### PR TITLE
Move catkin_package macro so it is called before targets are defined.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,13 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(gazebo REQUIRED)
 find_package(Boost REQUIRED)
 
+catkin_package(
+  DEPENDS 
+    roscpp 
+    gazebo_ros
+    control_toolbox
+)
+
 link_directories(${GAZEBO_LIBRARY_DIRS})
 include_directories(${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} include)
 
@@ -21,9 +28,3 @@ target_link_libraries(roboticsgroup_gazebo_mimic_joint_plugin ${catkin_LIBRARIES
 add_library(roboticsgroup_gazebo_disable_link_plugin src/disable_link_plugin.cpp)
 target_link_libraries(roboticsgroup_gazebo_disable_link_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
 
-catkin_package(
-  DEPENDS 
-    roscpp 
-    gazebo_ros
-    control_toolbox
-)


### PR DESCRIPTION
We ran into issues with plugins not getting found by Gazebo when building using catkin tools. The PR fixes the issue by calling the `catkin_package` macro before defining targets.
