### PR TITLE
Add missing setForce() call (otherwise PID option doesn't do anything)

### DIFF
--- a/src/mimic_joint_plugin.cpp
+++ b/src/mimic_joint_plugin.cpp
@@ -163,6 +163,7 @@ void MimicJointPlugin::UpdateChild()
         a = angle;
       double error = angle-a;
       double effort = gazebo::math::clamp(pid_.computeCommand(error, period), -max_effort_, max_effort_);
+      mimic_joint_->SetForce(0, effort);
     }
     else
       mimic_joint_->SetAngle(0, math::Angle(angle));


### PR DESCRIPTION
As above. Someone forgot to actually apply the effort that is computed :)
Tested with a parallel kinematics robot hand and confirmed working there.
