### PR TITLE
ROS Kinetic, Ubuntu 16.04 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(catkin REQUIRED COMPONENTS
   control_toolbox
 )
 
+add_definitions(-std=gnu++0x)
+
 # Depend on system install of Gazebo
 find_package(gazebo REQUIRED)
 find_package(Boost REQUIRED)

--- a/src/mimic_joint_plugin.cpp
+++ b/src/mimic_joint_plugin.cpp
@@ -139,7 +139,7 @@ void MimicJointPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf )
   
   // Set max effort
   if(!has_pid_)
-    mimic_joint_->SetMaxForce(0,max_effort_);
+    mimic_joint_->SetEffortLimit(0,max_effort_);
 
   // Listen to the update event. This event is broadcast every
   // simulation iteration.
@@ -166,7 +166,7 @@ void MimicJointPlugin::UpdateChild()
       mimic_joint_->SetForce(0, effort);
     }
     else
-      mimic_joint_->SetAngle(0, math::Angle(angle));
+      mimic_joint_->SetPosition(0, angle);
   }
 }
 


### PR DESCRIPTION
Perhaps this should go on a different branch as it breaks compatibility. Anyways...let me know if there's interest in taking this and I'll create a PR against some other branch. These changes make the package compile on Ubuntu 16.04 with ROS Kinetic and Gazebo 7.
