### PR TITLE
Set CMP0054 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.6 FATAL_ERROR)
 project(roboticsgroup_gazebo_plugins)
 
+# Set CMP0054
+cmake_policy(SET CMP0054 NEW)
+
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   roscpp


### PR DESCRIPTION
I found the following warning message appears on Melodic environment with Gazebo9. 

This warning would comes from the difference of CMake version between this package and Gazebo9. Direct setting CMP0054 (this PR) solves it. 
```
Warnings   << roboticsgroup_gazebo_plugins:check {catkin_ws}/logs/roboticsgroup_gazebo_plugins/build.check.006.log
CMake Warning (dev) at /usr/share/cmake-3.10/Modules/FindBoost.cmake:911 (if):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "chrono" will no longer be dereferenced when the
  policy is set to NEW.  Since the policy is not set the OLD behavior will be
  used.
Call Stack (most recent call first):
  /usr/share/cmake-3.10/Modules/FindBoost.cmake:1558 (_Boost_MISSING_DEPENDENCIES)
  /usr/share/OGRE/cmake/modules/FindOGRE.cmake:318 (find_package)
  /usr/lib/x86_64-linux-gnu/cmake/gazebo/gazebo-config.cmake:175 (find_package)
  CMakeLists.txt:12 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```