### PR TITLE
Use SetParam for effort limit

### DIFF
--- a/src/mimic_joint_plugin.cpp
+++ b/src/mimic_joint_plugin.cpp
@@ -132,7 +132,7 @@ namespace gazebo {
         // Set max effort
         if (!has_pid_) {
 #if GAZEBO_MAJOR_VERSION > 2
-            mimic_joint_->SetEffortLimit(0, max_effort_);
+            mimic_joint_->SetParam("fmax", 0, max_effort_);
 #else
             mimic_joint_->SetMaxForce(0, max_effort_);
 #endif


### PR DESCRIPTION
This has been driving me crazy. My vertical prismatic joints would keep falling down when in position control. SetEffortLimit has no effect.

It follows the example of [default_robot_hw_sim](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros_control/src/default_robot_hw_sim.cpp#L240).